### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/EmployeeCrud/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/EmployeeCrud/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1044,7 +1044,8 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			var sanitizedElement = this.escapeCssMeta(element);
+			return $( sanitizedElement ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/Rutwik-28/EmployeeCrud/security/code-scanning/2](https://github.com/Rutwik-28/EmployeeCrud/security/code-scanning/2)

To fix the problem, we need to ensure that any user input used in jQuery selectors is properly sanitized. Specifically, we should use the `escapeCssMeta` function to sanitize the `element` variable before it is used in the jQuery selector on line 1047. This will prevent any malicious input from being executed as part of the selector.

1. Identify the line where the untrusted data is used in a jQuery selector.
2. Apply the `escapeCssMeta` function to sanitize the input before using it in the selector.
3. Ensure that the fix does not change the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
