### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/EmployeeCrud/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/EmployeeCrud/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -660,7 +660,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return $( document ).find( selector )[ 0 ];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Rutwik-28/EmployeeCrud/security/code-scanning/1](https://github.com/Rutwik-28/EmployeeCrud/security/code-scanning/1)

To fix the problem, we need to ensure that the `selector` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of the `jQuery` method. The `jQuery.find` method always interprets the input as a CSS selector, which prevents the risk of XSS.

- Replace the use of `$(selector)` with `$(document).find(selector)` in the `clean` function.
- This change ensures that the `selector` parameter is always treated as a CSS selector and not as HTML, mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
